### PR TITLE
Add support for replying as a thread

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,11 @@
             "description": "The URL of your Piazza class.",
             "required": true,
             "value": "https://piazza.com/class/CLASS_NOT_SET"
-    }
+    },
+    "REPLY_AS_THREAD": {
+            "description": "Should the bot reply as a thread? Leave empty for no, put any value for yes.",
+            "required": false,
+            "value": "LEAVE EMPTY FOR NO, PUT ANY VALUE FOR YES"
+    },
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,11 @@ var config = {
   // The URL of your Piazza class.
   piazza_base_url: process.env['PIAZZA_BASE_URL'],
 
+  // Should the bot reply as a thread? If not, just sends a message to the channel.
+  // If the message that triggers the bot is already in a thread, then the bot
+  // will always respond to that thread, no matter the value of this setting.
+  reply_as_thread: process.env['REPLY_AS_THREAD'] || false,
+
   // Whether or not to use the Slack Real-Time Messaging API instead of the Events API.
   use_rtm: process.env['USE_RTM'] || false,
 
@@ -16,7 +21,7 @@ var config = {
     signing_secret: process.env['SLACK_SIGNING_SECRET']
   },
 
-  /*** No need to modify anything below this ***/
+  /** No need to modify anything below this **/
 
   regexes: [],
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,22 @@ client.on('message', (message) => {
 
   regexbot.respond(message.text, (reply) => {
     console.log('Responding with: ' + reply);
-    postMessage({ channel: message.channel, text: reply, as_user: true });
+
+    var replyMessage = {
+      channel: message.channel,
+      text: reply,
+      as_user: true
+    };
+
+    // If bot is configured to reply as a thread, or if the message that 
+    // triggered the bot was already a threaded reply, then add a 'thread_ts'
+    // so that the bot replies inside the thread.
+    if (config.reply_as_thread || message.thread_ts !== undefined) {
+      console.log("has it!")
+      replyMessage.thread_ts = message.thread_ts || message.ts;
+    }
+
+    postMessage(replyMessage);
   });
 });
 


### PR DESCRIPTION
As per #1, this adds the ability to configure the bot so that it replies as a thread.

Additionally, if the message that triggers the bot is already part of a thread, the bot will always reply as part of that thread (rather than to the channel), regardless of what reply_as_thread is set to.

I am waiting to merge this until I am able to test a bug fix for duplicated responses.