### PR TITLE
Initial implementation of retry filtering

### DIFF
--- a/HOW-TO-UPDATE.md
+++ b/HOW-TO-UPDATE.md
@@ -1,0 +1,31 @@
+# How to Update `piazza-link-bot`
+
+So you've got an outdated Piazza bot, huh? Well don't worry, here's how to quickly update your deployment!
+
+## Method A: Command Line
+
+This is the most straightforward method. It requires that you have the heroku CLI installed.
+
+1. Check to see if any new Environment variables were added in the update. If so, you should update these in your Heroku app's settings before proceeding.
+1. Clone the up-to-date `piazza-link-bot` repo to your local machine
+    ```
+    $ git clone https://github.com/BGR360/piazza-link-bot
+    ```
+1. Force push the code directly to your Heroku app instance
+    ```
+    $ heroku login
+	$ git remote add heroku https://git.heroku.com/YOUR-PIAZZA-LINK-BOT-APP-NAME.git
+	$ git push -f heroku master
+    ```
+
+## Method B: Fork and Browser
+
+If you really don't wanna install Heroku CLI, then you can try this method.
+
+1. Check to see if any new Environment variables were added in the update. If so, you should update these in your Heroku app's settings before proceeding.
+1. Fork this repo to your GitHub account.
+1. Go to your heroku dashboard and click on your piazza link bot app.
+1. Go to the "Deploy" menu.
+1. Under "Deployment method", select GitHub as the option.
+1. Grant Heroku permissions.
+1. Select your fork of the repo and use that to deploy.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ Based on [regexbot](https://github.com/sjmelia/regexbot) by sjmelia.
 
 ![Example image](https://i.gyazo.com/3fbcb71b81845b5ca65cef08af1334d8.png)
 
+
+Got an out-of-date deployment?
+------------------------------
+
+Go to [HOW-TO-UPDATE.md](HOW_TO_UPDATE.md) for instructions on how to update your deployment to the latest version.
+
+
 Full instructions
------
+-----------------
 
 ### Create Slack App
 

--- a/app.json
+++ b/app.json
@@ -25,6 +25,10 @@
             "description": "The URL of your Piazza class.",
             "required": true,
             "value": "https://piazza.com/class/CLASS_NOT_SET"
+    },
+    "RETRY_MEMORY": {
+            "description": "Number of message ids to hold in memory to prevent duplicate messages (linear search involved) (default=100)",
+            "required": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "regexbot",
+  "name": "piazza-link-bot",
   "version": "1.0.0",
-  "description": "Regular expression responder for slack",
-  "repository": "https://github.com/sjmelia/regexbot",
+  "description": "Slackbot that responds with links to Piazza posts",
+  "repository": "https://github.com/bgr360/piazza-link-bot",
   "main": "src/index.js",
   "dependencies": {
     "@slack/client": "^4.8.0",
     "@slack/events-api": "^2.1.1",
-    "app.json": "^1.3.0",
     "jira-client": "^4.2.0",
     "node-schedule": "^1.2.0"
   },
@@ -25,6 +24,6 @@
     "start": "node src/index.js",
     "test": "eslint src && mocha"
   },
-  "author": "Steve Melia",
+  "author": "Ben Reeves",
   "license": "MIT"
 }

--- a/src/config.js
+++ b/src/config.js
@@ -16,11 +16,14 @@ var config = {
     signing_secret: process.env['SLACK_SIGNING_SECRET']
   },
 
-  /*** No need to modify anything below this ***/
+  /** No need to modify anything below this **/
 
   regexes: [],
 
   schedules: [],
+
+  // Number of message ids to keep in memory in order to prevent duplicate replies.
+  retryMemory: process.env['RETRY_MEMORY'] || 100,
 
   build: function (id) {
     this.regexes.push({ regex: /@(\d+)/g, message: this.piazza_base_url + '?cid=[1]' });

--- a/src/retryfilter.js
+++ b/src/retryfilter.js
@@ -1,0 +1,71 @@
+/**
+ * Slack API will retry messages if they take too long.
+ * When a Heroku dyno is starting up, it typically receives
+ * the same message 3 times due to this retry, causing the bot
+ * to send 3 identical replies. This is a solution to this problem.
+ *
+ * SECURITY / PRIVACY NOTE:
+ * None of the contents of messages are kept in memory longer than needed.
+ * Only the unique timestamp and channel id of the message are stored
+ * in the previousMessages array.
+ */
+function RetryFilter (config) {
+  this.config = config;
+  this.previousMessages = [];
+
+  this.addMessage = addMessage;
+  this.filter = filter;
+  this.isRetry = isRetry;
+
+  /**
+   * Adds a message to the memory and removes an old one if necessary.
+   * Returns the message that was popped from the front, if it was, otherwise null.
+   */
+  function addMessage (message) {
+    this.previousMessages.push({
+      ts: message.ts,
+      channel: message.channel
+    });
+
+    // Remove first item of array if array too big
+    while (this.previousMessages.length > this.config.retryMemory) {
+      let popped = this.previousMessages[0];
+      this.previousMessages.shift();
+      return popped;
+    }
+
+    return null;
+  }
+
+  /**
+   * Calls callback only if the message is not a repeat,
+   * otherwise calls ifRetry
+   */
+  function filter (message, callback, ifRetry) {
+    if (this.isRetry(message)) {
+      if (ifRetry !== undefined) {
+        ifRetry(message);
+      }
+    } else {
+      callback(message);
+    }
+  }
+
+  function isRetry (message) {
+    if (this.previousMessages.length === 0) {
+      return false;
+    }
+
+    // Search through to see if any of them have the same timestamp and channel number
+    for (let i = 0; i < this.previousMessages.length; i++) {
+      let prevMsg = this.previousMessages[i];
+      if (prevMsg.ts === message.ts && prevMsg.channel === message.channel) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+module.exports = RetryFilter;

--- a/test/testRetryFilter.js
+++ b/test/testRetryFilter.js
@@ -1,0 +1,174 @@
+/* global describe it */
+const assert = require('chai').assert;
+const RetryFilter = require('../src/retryfilter');
+const config = {
+  retryMemory: 5
+};
+
+const messages = [
+  {
+    type: "message",
+    channel: "C123",
+    user: "U0",
+    text: "Message 0",
+    ts: "100.00"
+  },
+
+  // Three messages with same timestamp but different channel
+  {
+    type: "message",
+    channel: "C123",
+    user: "U0",
+    text: "Message 1",
+    ts: "100.01"
+  },
+  {
+    type: "message",
+    channel: "C242",
+    user: "U0",
+    text: "Message 2",
+    ts: "100.01"
+  },
+  {
+    type: "message",
+    channel: "C999",
+    user: "U0",
+    text: "Message 3",
+    ts: "100.01"
+  },
+
+  {
+    type: "message",
+    channel: "C123",
+    user: "U0",
+    text: "Message 4",
+    ts: "200.12"
+  },
+  {
+    type: "message",
+    channel: "C123",
+    user: "U0",
+    text: "Message 4",
+    ts: "200.12"
+  },
+];
+
+function feedNMessages (retryFilter, beginIndex, n) {
+  for (let i = beginIndex; i < beginIndex + n; i++) {
+    retryFilter.addMessage(messages[i]);
+  }
+}
+
+describe('RetryFilter', function () {
+  let retryFilter;
+
+  beforeEach(function () {
+    retryFilter = new RetryFilter(config);
+  });
+
+  it('should pop off elements when it reaches max capacity', function () {
+    let firstMessage = {
+      ts: messages[0].ts,
+      channel: messages[0].channel
+    };
+    let secondMessage = {
+      ts: messages[1].ts,
+      channel: messages[1].channel
+    };
+
+    feedNMessages(retryFilter, 0, 5);
+    
+    let popped = retryFilter.addMessage(messages[5]);
+    assert.deepEqual(firstMessage, popped);
+
+    popped = retryFilter.addMessage(messages[5]);
+    assert.deepEqual(secondMessage, popped);
+  });
+
+  it('should work with zero retryMemory', function () {
+    retryFilter = new RetryFilter({
+      retryMemory: 0
+    });
+    feedNMessages(retryFilter, 0, 5);
+    assert.isFalse(retryFilter.isRetry(messages[0]));
+    assert.isFalse(retryFilter.isRetry(messages[1]));
+    assert.isFalse(retryFilter.isRetry(messages[2]));
+    assert.isFalse(retryFilter.isRetry(messages[3]));
+    assert.isFalse(retryFilter.isRetry(messages[4]));
+    assert.isFalse(retryFilter.isRetry(messages[5]));
+  });
+
+  describe('#isRetry', function () {
+    it('should return false if no messages have been received', function () {
+      assert.isFalse(retryFilter.isRetry(messages[0]));
+    });
+
+    it('should return true when searching for a repeat message', function () {
+      feedNMessages(retryFilter, 0, 1);
+      assert.isTrue(retryFilter.isRetry(messages[0]));
+    });
+
+    it('should return false when message has not been received', function () {
+      feedNMessages(retryFilter, 0, 1);
+      assert.isFalse(retryFilter.isRetry(messages[3]));
+    });
+
+    it('should return true when multiple messages have same timestamp', function () {
+      feedNMessages(retryFilter, 0, 5);
+      assert.isTrue(retryFilter.isRetry(messages[1]));
+      assert.isTrue(retryFilter.isRetry(messages[2]));
+      assert.isTrue(retryFilter.isRetry(messages[3]));
+    });
+
+    it('should return false if timestamp matches but channel does not', function () {
+      let msg = {
+        type: "message",
+        channel: "C4343434343",
+        user: "U0",
+        text: "Almost the same message",
+        ts: "100.01"
+      };
+      feedNMessages(retryFilter, 0, 5);
+      assert.isFalse(retryFilter.isRetry(msg));
+    });
+
+    it('should return false if channel matches but timestamp does not', function () {
+      let msg = {
+        type: "message",
+        channel: "C123",
+        user: "U0",
+        text: "Almost the same message",
+        ts: "111.111"
+      };
+      feedNMessages(retryFilter, 0, 5);
+      assert.isFalse(retryFilter.isRetry(msg));
+    });
+  });
+
+  describe('#filter', function () {
+    it('should call callback when message is not a repeat', function (done) {
+      feedNMessages(retryFilter, 0, 5);
+      const ifOkay = (msg) => {
+        assert.deepEqual(msg, messages[5]);
+        done();
+      };
+      const ifRetry = (msg) => {
+        done(false);
+      };
+      retryFilter.filter(messages[5], ifOkay, ifRetry);
+    });
+
+    it('should call ifRetry when message is a repeat', function (done) {
+      feedNMessages(retryFilter, 0, 5);
+      let message = null;
+      const ifOkay = (msg) => {
+        done(false);
+      };
+      const ifRetry = (msg) => {
+        assert.equal(messages[0], msg);
+        done();
+      };
+      retryFilter.filter(messages[0], ifOkay, ifRetry);
+    });
+  });
+});


### PR DESCRIPTION
This is a fix for the bug where a Heroku-deployed Piazza bot will send duplicate responses if the dyno was asleep when the Slack API sent its event over.

The reason this happens is because Slack Events API retries on exponential backoff if the bot does not reply instantly. This wouldn't typically result in (say, if the first attempt was dropped); however, Heroku *holds* the pending POST request and waits for the dyno to start up, then sends it to the bot. So the bot receives both the original POST and all of the retries, and responds to all of them.

Going to merge as soon as I can test this (have to wait an hour so my dyno goes to sleep).